### PR TITLE
Move deployment configuration to runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Host build output contains platform-specific paths and must never enter a Linux image build.
+**/bin/
+**/obj/
+**/publish/
+**/TestResults/
+
+# Source control and CI metadata are not build inputs.
+.git/
+.gitignore
+.gitattributes
+.github/
+
+# IDE and editor state.
+.vs/
+.vscode/
+.idea/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+
+# Docker reads these before constructing the build context.
+Dockerfile
+.dockerignore
+
+# Database artifacts are built and published separately.
+Dacpac/
+**/*.dacpac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   CONFIGURATION: Release
-  DOTNET_CORE_VERSION: 8.0.x
+  DOTNET_CORE_VERSION: 10.0.x
   WORKING_DIRECTORY: src/DokkanDaily
   DACPAC_NAME: DokkanDailyDB.dacpac
 jobs:
@@ -77,7 +77,7 @@ jobs:
       run: |
         cd src/DokkanDailyDB/
         docker build . --build-arg PASSWORD="<YourStrong@Passw0rd>" -t mydatabase:1.0 --no-cache
-        docker run -p 1433:1433 --name sqldb -d mydatabase:1.0
+        docker run -p 127.0.0.1:1433:1433 --name sqldb -d mydatabase:1.0
         cd ../..
       
     - name: Test
@@ -136,8 +136,11 @@ jobs:
       
   deploy:
     runs-on: ubuntu-latest
-    permissions: write-all
-    needs: build
+    permissions:
+      contents: read
+      id-token: write
+    needs: [build, db-deploy]
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
     - uses: actions/checkout@v4
     
@@ -158,26 +161,13 @@ jobs:
         
     - name: Docker Build
       run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/dokkandaily:${{ github.sha }} \
-        --build-arg AzureAccountName="${{ vars.AZURE_ACCOUNT_NAME }}" \
-        --build-arg AzureConnectionString="${{ secrets.BLOB_CONNECTION_STRING }}" \
-        --build-arg BlobContainerName="${{ vars.BLOB_CONTAINER_NAME }}" \
-        --build-arg BlobKey="${{ secrets.BLOB_KEY }}" \
-        --build-arg OAuth2ClientSecret="${{ secrets.OAUTH_CLIENT_SECRET }}" \
-        --build-arg OAuth2ClientId="${{ secrets.OAUTH_CLIENT_ID }}" \
-        --build-arg SqlServerConnectionString="${{ secrets.SQL_CONNECTION_STRING }}" \
-        --build-arg WebhookUrl="${{ secrets.DBC_WEBHOOKS_URL }}" \
-        --build-arg EnableJpParsing="true" \
-        --build-arg StageRepeatLimit="40" \
-        --build-arg EventRepeatLimit="10"
+        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/dokkandaily:${{ github.sha }}
         
     - name: Docker push
-      if: github.ref == 'refs/heads/master'
       run: |
         docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/dokkandaily:${{ github.sha }}
         
     - name: Deploy to Azure WebApp
-      if: github.ref == 'refs/heads/master'
       uses: azure/webapps-deploy@v2
       with:
         app-name: DokkanDaily
@@ -187,6 +177,7 @@ jobs:
   db-deploy:
     runs-on: windows-latest
     needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
     steps:
     - name: Download artifact (Database)
       uses: actions/download-artifact@v4
@@ -202,7 +193,6 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         
     - name: Deploy DACPAC to Azure
-      if: github.ref == 'refs/heads/master'
       uses: azure/sql-action@v2.3
       with:
         connection-string: ${{ secrets.SQL_CONNECTION_STRING }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,29 +3,21 @@ WORKDIR /app
 EXPOSE 8080
 EXPOSE 443
 
-ARG AzureAccountName
-ARG AzureConnectionString
-ARG BlobContainerName
-ARG BlobKey
-ARG SqlServerConnectionString
-ARG OAuth2ClientSecret
-ARG OAuth2ClientId
-ARG WebhookUrl
-ARG EnableJpParsing
-ARG StageRepeatLimit
-ARG EventRepeatLimit
+# Configuration is supplied at runtime through App Service application settings or `docker run -e`.
+# The application explicitly loads the existing DOTNET_ prefix after its JSON configuration, so
+# these values override appsettings.json without being recoverable from image history.
+#
+#   DOTNET_DokkanDailySettings__AzureBlobConnectionString
+#   DOTNET_DokkanDailySettings__AzureBlobContainerName
+#   DOTNET_DokkanDailySettings__SqlServerConnectionString
+#   DOTNET_DokkanDailySettings__OAuth2ClientSecret
+#   DOTNET_DokkanDailySettings__OAuth2ClientId
+#   DOTNET_DokkanDailySettings__WebhookUrl
+#   DOTNET_DokkanDailySettings__StageRepeatLimitDays
+#   DOTNET_DokkanDailySettings__EventRepeatLimitDays
+#   DOTNET_DokkanDailySettings__FeatureFlags__EnableJapaneseParsing
+#   DOTNET_DokkanDailySettings__FeatureFlags__EnablePruneJob
 
-ENV DOTNET_DokkanDailySettings__AzureAccountName=$AzureAccountName
-ENV DOTNET_DokkanDailySettings__AzureBlobConnectionString=$AzureConnectionString
-ENV DOTNET_DokkanDailySettings__AzureBlobContainerName=$BlobContainerName
-ENV DOTNET_DokkanDailySettings__AzureBlobKey=$BlobKey
-ENV DOTNET_DokkanDailySettings__SqlServerConnectionString=$SqlServerConnectionString
-ENV DOTNET_DokkanDailySettings__OAuth2ClientSecret=$OAuth2ClientSecret
-ENV DOTNET_DokkanDailySettings__OAuth2ClientId=$OAuth2ClientId
-ENV DOTNET_DokkanDailySettings__WebhookUrl=$WebhookUrl
-ENV DOTNET_DokkanDailySettings__StageRepeatLimitDays=$StageRepeatLimit
-ENV DOTNET_DokkanDailySettings__EventRepeatLimitDays=$EventRepeatLimit
-ENV DOTNET_DokkanDailySettings__FeatureFlags__EnableJapaneseParsing=$EnableJpParsing
 ENV LD_LIBRARY_PATH="/lib:/usr/lib:/usr/local/lib"
 
 RUN apt-get update \

--- a/scripts/buildStagingContainer.cmd
+++ b/scripts/buildStagingContainer.cmd
@@ -2,16 +2,16 @@ cd ..
 docker stop dokkandaily || cd .
 docker rm dokkandaily || cd .
 docker image rm -f dokkandaily.azurecr.io/dokkandaily:staging || cd .
-docker build . -t dokkandaily.azurecr.io/dokkandaily:staging ^
---build-arg AzureAccountName="%DOTNET_DokkanDailySettings__AzureAccountName%" ^
---build-arg AzureConnectionString="%DOTNET_DokkanDailySettings__AzureBlobConnectionString%" ^
---build-arg BlobContainerName="stg-daily-clears" ^
---build-arg BlobKey="%DOTNET_DokkanDailySettings__AzureBlobKey%" ^
---build-arg OAuth2ClientSecret="%DOTNET_DokkanDailySettings__OAuth2ClientSecret%" ^
---build-arg OAuth2ClientId="%DOTNET_DokkanDailySettings__OAuth2ClientId%" ^
---build-arg SqlServerConnectionString="%DOTNET_DokkanDailySettings__SqlServerConnectionString%" ^
---build-arg WebhookUrl="%DOTNET_DokkanDailySettings__WebhookUrl%" ^
---build-arg EnableJpParsing="true" ^
---build-arg StageRepeatLimit="30" ^
---build-arg EventRepeatLimit="7"
-docker run --name dokkandaily -p 8080:8080 -d dokkandaily.azurecr.io/dokkandaily:staging
+docker build . -t dokkandaily.azurecr.io/dokkandaily:staging
+docker run --name dokkandaily -p 127.0.0.1:8080:8080 -d ^
+--env DOTNET_DokkanDailySettings__AzureBlobConnectionString ^
+--env DOTNET_DokkanDailySettings__AzureBlobContainerName ^
+--env DOTNET_DokkanDailySettings__OAuth2ClientSecret ^
+--env DOTNET_DokkanDailySettings__OAuth2ClientId ^
+--env DOTNET_DokkanDailySettings__SqlServerConnectionString ^
+--env DOTNET_DokkanDailySettings__WebhookUrl ^
+--env DOTNET_DokkanDailySettings__StageRepeatLimitDays ^
+--env DOTNET_DokkanDailySettings__EventRepeatLimitDays ^
+--env DOTNET_DokkanDailySettings__FeatureFlags__EnableJapaneseParsing ^
+--env DOTNET_DokkanDailySettings__FeatureFlags__EnablePruneJob ^
+dokkandaily.azurecr.io/dokkandaily:staging

--- a/scripts/buildStagingContainer.sh
+++ b/scripts/buildStagingContainer.sh
@@ -2,16 +2,16 @@ cd ..
 docker stop dokkandaily || true
 docker rm dokkandaily || true
 docker image rm -f dokkandaily.azurecr.io/dokkandaily:staging || true
-docker build . -t dokkandaily.azurecr.io/dokkandaily:staging \
---build-arg AzureAccountName="%DOTNET_DokkanDailySettings__AzureAccountName%" \
---build-arg AzureConnectionString="%DOTNET_DokkanDailySettings__AzureBlobConnectionString%" \
---build-arg BlobContainerName="stg-daily-clears" \
---build-arg BlobKey="%DOTNET_DokkanDailySettings__AzureBlobKey%" \
---build-arg OAuth2ClientSecret="%DOTNET_DokkanDailySettings__OAuth2ClientSecret%" \
---build-arg OAuth2ClientId="%DOTNET_DokkanDailySettings__OAuth2ClientId%" \
---build-arg SqlServerConnectionString="%DOTNET_DokkanDailySettings__SqlServerConnectionString%" \
---build-arg WebhookUrl="%DOTNET_DokkanDailySettings__WebhookUrl%" \
---build-arg EnableJpParsing="true" \
---build-arg StageRepeatLimit="30" \
---build-arg EventRepeatLimit="7"
-docker run --name dokkandaily -p 8080:8080 dokkandaily.azurecr.io/dokkandaily:staging
+docker build . -t dokkandaily.azurecr.io/dokkandaily:staging
+docker run --name dokkandaily -p 127.0.0.1:8080:8080 \
+--env DOTNET_DokkanDailySettings__AzureBlobConnectionString \
+--env DOTNET_DokkanDailySettings__AzureBlobContainerName \
+--env DOTNET_DokkanDailySettings__OAuth2ClientSecret \
+--env DOTNET_DokkanDailySettings__OAuth2ClientId \
+--env DOTNET_DokkanDailySettings__SqlServerConnectionString \
+--env DOTNET_DokkanDailySettings__WebhookUrl \
+--env DOTNET_DokkanDailySettings__StageRepeatLimitDays \
+--env DOTNET_DokkanDailySettings__EventRepeatLimitDays \
+--env DOTNET_DokkanDailySettings__FeatureFlags__EnableJapaneseParsing \
+--env DOTNET_DokkanDailySettings__FeatureFlags__EnablePruneJob \
+dokkandaily.azurecr.io/dokkandaily:staging

--- a/src/DokkanDaily/Configuration/DokkanDailySettings.cs
+++ b/src/DokkanDaily/Configuration/DokkanDailySettings.cs
@@ -2,13 +2,9 @@
 {
     public class DokkanDailySettings
     {
-        public string AzureBlobKey { get; init; }
-
         public string AzureBlobConnectionString { get; init; }
 
         public string AzureBlobContainerName { get; init; }
-
-        public string AzureAccountName { get; init; }
 
         public string SqlServerConnectionString { get; init; }
 

--- a/src/DokkanDaily/Program.cs
+++ b/src/DokkanDaily/Program.cs
@@ -17,6 +17,10 @@ namespace DokkanDaily
         {
             var builder = WebApplication.CreateBuilder(args);
 
+            // Existing Azure settings use the DOTNET_ prefix. Load them as application
+            // configuration after the defaults so they override appsettings.json as documented.
+            builder.Configuration.AddEnvironmentVariables(prefix: "DOTNET_");
+
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(builder.Configuration)
                 .Enrich.FromLogContext()

--- a/src/DokkanDaily/Services/AzureBlobService.cs
+++ b/src/DokkanDaily/Services/AzureBlobService.cs
@@ -1,5 +1,4 @@
 ﻿using Azure;
-using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
@@ -20,9 +19,7 @@ namespace DokkanDaily.Services
         private readonly ILogger<AzureBlobService> _logger;
         private readonly IOcrService _ocrService;
         private readonly string _connectionString;
-        private readonly string _azureKey;
         private readonly string _containerName;
-        private readonly string _accountName;
 
         private const int maxFileSize = 1024 * 8192;
 
@@ -33,9 +30,7 @@ namespace DokkanDaily.Services
             _settings = settings.Value;
             _logger = logger;
             _connectionString = _settings.AzureBlobConnectionString;
-            _azureKey = _settings.AzureBlobKey;
             _containerName = _settings.AzureBlobContainerName;
-            _accountName = _settings.AzureAccountName;
             _ocrService = ocrService;
         }
 
@@ -147,22 +142,26 @@ namespace DokkanDaily.Services
         {
             try
             {
+                BlobContainerClient container = new(_connectionString, bucket ?? TodaysBucketFullName);
+                BlobClient blob = container.GetBlobClient(fileName);
+
+                if (!blob.CanGenerateSasUri)
+                {
+                    _logger.LogError("The configured blob connection string cannot sign a read SAS for `{File}`.", fileName);
+                    return null;
+                }
+
                 BlobSasBuilder blobSasBuilder = new()
                 {
-                    BlobContainerName = bucket ?? TodaysBucketFullName,
+                    BlobContainerName = container.Name,
                     BlobName = fileName,
-                    ExpiresOn = DateTime.UtcNow.AddMinutes(2)
+                    StartsOn = DateTimeOffset.UtcNow.AddMinutes(-5),
+                    ExpiresOn = DateTimeOffset.UtcNow.AddMinutes(15)
                 };
 
                 blobSasBuilder.SetPermissions(BlobSasPermissions.Read);
 
-                var sasToken = blobSasBuilder.ToSasQueryParameters(
-                    new StorageSharedKeyCredential(
-                        _accountName,
-                        _azureKey))
-                    .ToString();
-
-                return sasToken;
+                return blob.GenerateSasUri(blobSasBuilder).Query.TrimStart('?');
             }
             catch (Exception ex)
             {

--- a/src/DokkanDaily/appsettings.json
+++ b/src/DokkanDaily/appsettings.json
@@ -6,5 +6,13 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "DokkanDailySettings": {
+    "StageRepeatLimitDays": 40,
+    "EventRepeatLimitDays": 10,
+    "FeatureFlags": {
+      "EnablePruneJob": false,
+      "EnableJapaneseParsing": true
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- move deployment settings to runtime configuration
- remove build-time secret injection
- update CI and staging launchers for .NET 10 and safer deployment ordering
- derive blob SAS credentials from the configured connection string

Azure environment secrets are already configured; this PR does not add or rotate them.

## Validation
- dotnet build src/DokkanDaily/DokkanDaily.csproj -c Release --no-restore