### PR TITLE
Limit daily upload attempts atomically

### DIFF
--- a/src/DokkanDaily/Components/Pages/Clears.razor
+++ b/src/DokkanDaily/Components/Pages/Clears.razor
@@ -4,6 +4,7 @@
 @using DokkanDaily.Components.Shared
 @using DokkanDaily.Constants
 @using DokkanDaily.Extensions
+@using DokkanDaily.Exceptions
 @using DokkanDaily.Helpers
 @using DokkanDaily.Models
 @using DokkanDaily.Models.ViewModel
@@ -15,6 +16,7 @@
 @inject IRngHelperService RngSvc
 @inject AuthenticationStateProvider authStateProvider;
 @inject IHttpContextAccessor HttpContextAccessor
+@inject ILogger<Clears> Logger
 
 <PageTitle>Dokkandle!</PageTitle>
 <style>
@@ -97,8 +99,16 @@
     private const string defaultWarning = "Something went wrong! Please try again.";
     private Challenge challengeModel;
 
+    // HttpContext is valid during prerendering but not during interactive events. Blazor restores
+    // this protected value when the component becomes interactive, so anonymous admission remains
+    // keyed to the address resolved by forwarded-header middleware.
+    [PersistentState]
+    public string RemoteIpAddress { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
+        RemoteIpAddress ??= HttpContextAccessor.HttpContext?.GetUserIpAddress();
+
         try
         {
             challengeModel = await RngSvc.GetDailyChallenge();
@@ -138,7 +148,7 @@
         Message = $"{selectedFiles.Count} file(s) selected";
         this.StateHasChanged();
     }
-    private async void OnUploadSubmit()
+    private async Task OnUploadSubmit()
     {
         string remoteUserAgent = null;
 
@@ -170,7 +180,7 @@
                 userAgent: remoteUserAgent,
                 discordUsername: discordUsername,
                 discordId: discordId,
-                remoteIp: HttpContextAccessor?.HttpContext?.GetUserIpAddress());
+                remoteIp: RemoteIpAddress);
 
             FileUploadViewModel fileUploadViewModel = new FileUploadViewModel()
             {
@@ -182,9 +192,14 @@
             fileUploadViewModels.Add(fileUploadViewModel);
             Message = file.Name + " Uploaded!!";
         }
-        catch (Exception ex)
+        catch (UploadRejectedException ex)
         {
             warningMessage = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to upload clear `{File}`", file.Name);
+            warningMessage = defaultWarning;
         }
 
         fileLoading = false;

--- a/src/DokkanDaily/Components/Pages/StageChallenge.razor
+++ b/src/DokkanDaily/Components/Pages/StageChallenge.razor
@@ -121,5 +121,7 @@ else
         base.OnInitialized();
     }
 
-    void OnClick() => NavManager.NavigateTo("/clears", false);
+    // A full navigation guarantees that Clears is prerendered with the current request address,
+    // which is then persisted into its interactive component state.
+    void OnClick() => NavManager.NavigateTo("/clears", true);
 }

--- a/src/DokkanDaily/Exceptions/UploadRejectedException.cs
+++ b/src/DokkanDaily/Exceptions/UploadRejectedException.cs
@@ -1,0 +1,6 @@
+namespace DokkanDaily.Exceptions
+{
+    public sealed class UploadRejectedException(string message) : Exception(message)
+    {
+    }
+}

--- a/src/DokkanDaily/Extensions/HttpContextExtensions.cs
+++ b/src/DokkanDaily/Extensions/HttpContextExtensions.cs
@@ -1,16 +1,19 @@
-﻿namespace DokkanDaily.Extensions
+namespace DokkanDaily.Extensions
 {
     public static class HttpContextExtensions
     {
         public static string GetUserIpAddress(this HttpContext context)
         {
-            // Check X-Forwarded-For header
-            if (!string.IsNullOrEmpty(context.Request.Headers["X-Forwarded-For"]))
-                return context.Request.Headers["X-Forwarded-For"];
+            System.Net.IPAddress address = context?.Connection?.RemoteIpAddress;
 
-            // Fallback to RemoteIpAddress
-            return context.Connection.RemoteIpAddress?.ToString();
+            if (address is null ||
+                address.Equals(System.Net.IPAddress.Any) ||
+                address.Equals(System.Net.IPAddress.IPv6Any))
+            {
+                return null;
+            }
+
+            return (address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address).ToString();
         }
-
     }
 }

--- a/src/DokkanDaily/Models/UploadAdmission.cs
+++ b/src/DokkanDaily/Models/UploadAdmission.cs
@@ -1,0 +1,4 @@
+namespace DokkanDaily.Models
+{
+    public sealed record UploadAdmission(bool Accepted, string UploaderKey, DateOnly UtcDate, string RejectionMessage = null);
+}

--- a/src/DokkanDaily/Program.cs
+++ b/src/DokkanDaily/Program.cs
@@ -39,6 +39,11 @@ namespace DokkanDaily
             {
                 options.ForwardedHeaders =
                     ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+                // Azure App Service is the ingress trust boundary. ForwardLimit remains one, so
+                // only the address appended by the platform proxy is consumed.
+                options.KnownIPNetworks.Clear();
+                options.KnownProxies.Clear();
             });
 
             builder.Services.AddHostedService<Worker>();
@@ -51,7 +56,9 @@ namespace DokkanDaily
             builder.Services.AddTransient<IResetService, ResetService>();
             builder.Services.AddTransient<IAzureBlobService, AzureBlobService>();
             builder.Services.AddTransient<IOcrService, OcrService>();
+            builder.Services.AddTransient<IUploadAttemptLimiter, UploadAttemptLimiter>();
             builder.Services.AddTransient<IDokkanDailyRepository, DokkanDailyRepository>();
+            builder.Services.AddSingleton(TimeProvider.System);
 
             // TODO: IP tracking to enforce bans (sadface)
             builder.Services.AddScoped<BlazorAppContext>();

--- a/src/DokkanDaily/Properties/AssemblyInfo.cs
+++ b/src/DokkanDaily/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DokkanDailyTests")]

--- a/src/DokkanDaily/Repository/DokkanDailyRepository.cs
+++ b/src/DokkanDaily/Repository/DokkanDailyRepository.cs
@@ -128,6 +128,20 @@ namespace DokkanDaily.Repository
             return results;
         }
 
+        public async Task<bool> TryAcceptUploadAttempt(string uploaderKey, DateOnly utcDate)
+        {
+            using SqlConnection sqlConnection = new(_connectionString);
+
+            await sqlConnection.OpenAsync();
+
+            DynamicParameters parameters = new();
+            parameters.Add("UploaderKey", uploaderKey);
+            parameters.Add("AttemptDate", utcDate.ToDateTime(TimeOnly.MinValue));
+
+            return await sqlConnection.QuerySingleAsync<bool>(
+                "[Core].[UploadAttemptTryAccept]", parameters);
+        }
+
         private DataTable ToDataTable<T>(IEnumerable<T> values) where T : class
         {
             Type type = typeof(T);

--- a/src/DokkanDaily/Repository/IDokkanDailyRepository.cs
+++ b/src/DokkanDaily/Repository/IDokkanDailyRepository.cs
@@ -14,5 +14,7 @@ namespace DokkanDaily.Repository
         Task<IEnumerable<DbLeaderboardResult>> GetLeaderboardByDate(DateTime monthAndYear);
 
         Task<IEnumerable<DbLeaderboardResult>> GetHallOfFame();
+
+        Task<bool> TryAcceptUploadAttempt(string uploaderKey, DateOnly utcDate);
     }
 }

--- a/src/DokkanDaily/Services/AzureBlobService.cs
+++ b/src/DokkanDaily/Services/AzureBlobService.cs
@@ -4,6 +4,7 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
 using DokkanDaily.Configuration;
 using DokkanDaily.Constants;
+using DokkanDaily.Exceptions;
 using DokkanDaily.Helpers;
 using DokkanDaily.Models;
 using DokkanDaily.Models.Enums;
@@ -18,6 +19,7 @@ namespace DokkanDaily.Services
         private readonly DokkanDailySettings _settings;
         private readonly ILogger<AzureBlobService> _logger;
         private readonly IOcrService _ocrService;
+        private readonly IUploadAttemptLimiter _uploadAttemptLimiter;
         private readonly string _connectionString;
         private readonly string _containerName;
 
@@ -25,13 +27,14 @@ namespace DokkanDaily.Services
 
         private string TodaysBucketFullName => GetBucketNameForDate(DokkanDailyHelper.GetUtcNowDateTag());
 
-        public AzureBlobService(IOptions<DokkanDailySettings> settings, ILogger<AzureBlobService> logger, IOcrService ocrService)
+        public AzureBlobService(IOptions<DokkanDailySettings> settings, ILogger<AzureBlobService> logger, IOcrService ocrService, IUploadAttemptLimiter uploadAttemptLimiter)
         {
             _settings = settings.Value;
             _logger = logger;
             _connectionString = _settings.AzureBlobConnectionString;
             _containerName = _settings.AzureBlobContainerName;
             _ocrService = ocrService;
+            _uploadAttemptLimiter = uploadAttemptLimiter;
         }
 
         public string GetBucketNameForDate(string formattedDateTag)
@@ -41,6 +44,10 @@ namespace DokkanDaily.Services
 
         public async Task<BlobClient> UploadToAzureAsync(string userFileName, string contentType, IBrowserFile browserFile, Challenge model, string bucket = null, string userAgent = null, string discordUsername = null, string discordId = null, string remoteIp = null)
         {
+            UploadAdmission admission = await _uploadAttemptLimiter.TryAcceptAsync(discordId, remoteIp);
+            if (!admission.Accepted)
+                throw new UploadRejectedException(admission.RejectionMessage);
+
             try
             {
                 var (container, _) = await GetOrCreate(bucket);

--- a/src/DokkanDaily/Services/Interfaces/IUploadAttemptLimiter.cs
+++ b/src/DokkanDaily/Services/Interfaces/IUploadAttemptLimiter.cs
@@ -1,0 +1,9 @@
+using DokkanDaily.Models;
+
+namespace DokkanDaily.Services.Interfaces
+{
+    public interface IUploadAttemptLimiter
+    {
+        Task<UploadAdmission> TryAcceptAsync(string discordId, string normalizedClientIp);
+    }
+}

--- a/src/DokkanDaily/Services/UploadAttemptLimiter.cs
+++ b/src/DokkanDaily/Services/UploadAttemptLimiter.cs
@@ -1,0 +1,59 @@
+using DokkanDaily.Models;
+using DokkanDaily.Repository;
+using DokkanDaily.Services.Interfaces;
+using System.Net;
+
+namespace DokkanDaily.Services
+{
+    public sealed class UploadAttemptLimiter(IDokkanDailyRepository repository, TimeProvider timeProvider) : IUploadAttemptLimiter
+    {
+        public const string LimitReachedMessage = "You've reached the limit of five upload attempts for today (UTC). Please try again tomorrow";
+        public const string MissingAddressMessage = "We couldn't verify your network address. Sign in with Discord or try again later";
+
+        private readonly IDokkanDailyRepository _repository = repository;
+        private readonly TimeProvider _timeProvider = timeProvider;
+
+        public async Task<UploadAdmission> TryAcceptAsync(string discordId, string normalizedClientIp)
+        {
+            DateOnly utcDate = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime);
+            string uploaderKey;
+
+            if (!string.IsNullOrWhiteSpace(discordId))
+            {
+                uploaderKey = $"discord:{discordId.Trim()}";
+            }
+            else if (TryNormalizeIpAddress(normalizedClientIp, out string ipAddress))
+            {
+                uploaderKey = $"ip:{ipAddress}";
+            }
+            else
+            {
+                return new(false, null, utcDate, MissingAddressMessage);
+            }
+
+            bool accepted = await _repository.TryAcceptUploadAttempt(uploaderKey, utcDate);
+
+            return accepted
+                ? new(true, uploaderKey, utcDate)
+                : new(false, uploaderKey, utcDate, LimitReachedMessage);
+        }
+
+        internal static bool TryNormalizeIpAddress(string value, out string normalized)
+        {
+            normalized = null;
+
+            if (!IPAddress.TryParse(value, out IPAddress address) ||
+                address.Equals(IPAddress.Any) ||
+                address.Equals(IPAddress.IPv6Any))
+            {
+                return false;
+            }
+
+            if (address.IsIPv4MappedToIPv6)
+                address = address.MapToIPv4();
+
+            normalized = address.ToString();
+            return true;
+        }
+    }
+}

--- a/src/DokkanDailyDB/Core/StoredProcedures/UploadAttemptTryAccept.sql
+++ b/src/DokkanDailyDB/Core/StoredProcedures/UploadAttemptTryAccept.sql
@@ -1,0 +1,59 @@
+CREATE PROCEDURE [Core].[UploadAttemptTryAccept]
+    @UploaderKey NVARCHAR(100),
+    @AttemptDate DATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
+
+    DECLARE @Accepted BIT = 0;
+    DECLARE @LockResult INT;
+    DECLARE @LockResource NVARCHAR(255) = CONCAT(N'DokkanDaily.UploadAttempt:', @AttemptDate, N':', @UploaderKey);
+
+    BEGIN TRY
+        BEGIN TRANSACTION;
+
+        EXEC @LockResult = sys.sp_getapplock
+            @Resource = @LockResource,
+            @LockMode = 'Exclusive',
+            @LockOwner = 'Transaction',
+            @LockTimeout = 15000;
+
+        IF @LockResult < 0
+            THROW 50001, 'Could not acquire the upload-attempt admission lock.', 1;
+
+        UPDATE [Core].[UploadAttempt]
+        SET [AttemptCount] = [AttemptCount] + 1
+        WHERE [UploaderKey] = @UploaderKey
+          AND [AttemptDate] = @AttemptDate
+          AND [AttemptCount] < 5;
+
+        IF @@ROWCOUNT = 1
+        BEGIN
+            SET @Accepted = 1;
+        END
+        ELSE IF NOT EXISTS
+        (
+            SELECT 1
+            FROM [Core].[UploadAttempt]
+            WHERE [UploaderKey] = @UploaderKey
+              AND [AttemptDate] = @AttemptDate
+        )
+        BEGIN
+            INSERT [Core].[UploadAttempt] ([UploaderKey], [AttemptDate], [AttemptCount])
+            VALUES (@UploaderKey, @AttemptDate, 1);
+
+            SET @Accepted = 1;
+        END;
+
+        COMMIT TRANSACTION;
+    END TRY
+    BEGIN CATCH
+        IF @@TRANCOUNT > 0
+            ROLLBACK TRANSACTION;
+
+        THROW;
+    END CATCH;
+
+    SELECT @Accepted AS [Accepted];
+END;

--- a/src/DokkanDailyDB/Core/Tables/UploadAttempt.sql
+++ b/src/DokkanDailyDB/Core/Tables/UploadAttempt.sql
@@ -1,0 +1,8 @@
+CREATE TABLE [Core].[UploadAttempt]
+(
+    [UploaderKey] NVARCHAR(100) NOT NULL,
+    [AttemptDate] DATE NOT NULL,
+    [AttemptCount] TINYINT NOT NULL,
+    CONSTRAINT [UploadAttempt_PK] PRIMARY KEY CLUSTERED ([UploaderKey], [AttemptDate]),
+    CONSTRAINT [UploadAttempt_CK01] CHECK ([AttemptCount] BETWEEN 1 AND 5)
+);

--- a/src/DokkanDailyDB/DokkanDailyDB.sqlproj
+++ b/src/DokkanDailyDB/DokkanDailyDB.sqlproj
@@ -79,6 +79,10 @@
     <Build Include="RefData\LoadDaily.sql" />
     <Build Include="RefData\LoadAllData.sql" />
     <Build Include="Core\StoredProcedures\LeaderboardGetByDate.sql" />
+    <Build Include="Core\Tables\UploadAttempt.sql" />
+    <Build Include="Core\StoredProcedures\UploadAttemptTryAccept.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Post-Deployment\Scripts\PostDeployment.sql" />

--- a/tests/DokkanDailyTests/DatabaseTests.cs
+++ b/tests/DokkanDailyTests/DatabaseTests.cs
@@ -42,7 +42,7 @@ namespace DokkanDailyTests
         public async Task Setup()
         {
             await conn.OpenAsync();
-            await conn.ExecuteReaderAsync("delete from Core.StageClear; delete from Core.DokkanDailyUser; delete from Core.DailyChallenge;", new());
+            await conn.ExecuteReaderAsync("delete from Core.StageClear; delete from Core.DokkanDailyUser; delete from Core.DailyChallenge; delete from Core.UploadAttempt;", new());
             await conn.CloseAsync();
         }
 
@@ -80,6 +80,19 @@ namespace DokkanDailyTests
             var list = result.ToList();
             Assert.That(list, Has.Count.EqualTo(2), "the returned leaderboard should have the correct number of elements");
             Assert.That(list.Any(x => x.DiscordId == "112089455933792256"), Is.True, "an element should contain a discord id");
+        }
+
+        [Test]
+        public async Task UploadAttemptAdmissionIsAtomicAcrossConcurrentConnectionsAndUtcDays()
+        {
+            DateOnly firstDay = new(2026, 8, 5);
+
+            bool[] admissions = await Task.WhenAll(Enumerable.Range(0, 40)
+                .Select(_ => repository.TryAcceptUploadAttempt("discord:concurrent", firstDay)));
+
+            Assert.That(admissions.Count(x => x), Is.EqualTo(5));
+            Assert.That(await repository.TryAcceptUploadAttempt("discord:concurrent", firstDay), Is.False);
+            Assert.That(await repository.TryAcceptUploadAttempt("discord:concurrent", firstDay.AddDays(1)), Is.True);
         }
 
         [Test]

--- a/tests/DokkanDailyTests/UploadAttemptLimiterTests.cs
+++ b/tests/DokkanDailyTests/UploadAttemptLimiterTests.cs
@@ -1,0 +1,89 @@
+using DokkanDaily.Extensions;
+using DokkanDaily.Models;
+using DokkanDaily.Repository;
+using DokkanDaily.Services;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using System.Net;
+
+namespace DokkanDailyTests
+{
+    [TestFixture]
+    public class UploadAttemptLimiterTests
+    {
+        [Test]
+        public async Task SixthAttemptForTheSameUploaderAndUtcDayIsRejected()
+        {
+            MutableTimeProvider clock = new(new DateTimeOffset(2026, 8, 5, 12, 0, 0, TimeSpan.Zero));
+            DateOnly date = new(2026, 8, 5);
+            Mock<IDokkanDailyRepository> repository = new();
+            repository.SetupSequence(x => x.TryAcceptUploadAttempt("discord:123456", date))
+                .ReturnsAsync(true)
+                .ReturnsAsync(true)
+                .ReturnsAsync(true)
+                .ReturnsAsync(true)
+                .ReturnsAsync(true)
+                .ReturnsAsync(false);
+            UploadAttemptLimiter limiter = new(repository.Object, clock);
+
+            UploadAdmission[] admissions = [];
+            for (int i = 0; i < 6; i++)
+                admissions = [.. admissions, await limiter.TryAcceptAsync("123456", null)];
+
+            Assert.That(admissions.Take(5).All(x => x.Accepted), Is.True);
+            Assert.That(admissions[5].Accepted, Is.False);
+        }
+
+        [Test]
+        public async Task AnonymousIdentityUsesCanonicalIpAndRejectsAnUnverifiableAddress()
+        {
+            Mock<IDokkanDailyRepository> repository = new();
+            repository.Setup(x => x.TryAcceptUploadAttempt(It.IsAny<string>(), It.IsAny<DateOnly>())).ReturnsAsync(true);
+            UploadAttemptLimiter limiter = new(repository.Object, new MutableTimeProvider(
+                new DateTimeOffset(2026, 8, 5, 12, 0, 0, TimeSpan.Zero)));
+
+            UploadAdmission mapped = await limiter.TryAcceptAsync(null, "::ffff:192.0.2.40");
+            UploadAdmission missing = await limiter.TryAcceptAsync(null, null);
+
+            Assert.That(mapped.UploaderKey, Is.EqualTo("ip:192.0.2.40"));
+            Assert.That(missing.Accepted, Is.False);
+            repository.Verify(x => x.TryAcceptUploadAttempt("ip:192.0.2.40", new DateOnly(2026, 8, 5)), Times.Once);
+        }
+
+        [Test]
+        public async Task LimitResetsAtTheUtcDayBoundary()
+        {
+            MutableTimeProvider clock = new(new DateTimeOffset(2026, 8, 5, 23, 59, 59, TimeSpan.Zero));
+            Mock<IDokkanDailyRepository> repository = new();
+            repository.Setup(x => x.TryAcceptUploadAttempt("discord:42", It.IsAny<DateOnly>())).ReturnsAsync(true);
+            UploadAttemptLimiter limiter = new(repository.Object, clock);
+
+            UploadAdmission firstDay = await limiter.TryAcceptAsync("42", null);
+            clock.UtcNow = new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero);
+            UploadAdmission secondDay = await limiter.TryAcceptAsync("42", null);
+
+            Assert.That(firstDay.UtcDate, Is.EqualTo(new DateOnly(2026, 8, 5)));
+            Assert.That(secondDay.UtcDate, Is.EqualTo(new DateOnly(2026, 8, 6)));
+        }
+
+        [Test]
+        public void ProxyProcessedRemoteAddressIsNormalizedWithoutReadingForwardedHeaders()
+        {
+            DefaultHttpContext context = new();
+            context.Request.Headers["X-Forwarded-For"] = "198.51.100.99";
+            context.Connection.RemoteIpAddress = IPAddress.Parse("::ffff:203.0.113.10");
+
+            Assert.That(context.GetUserIpAddress(), Is.EqualTo("203.0.113.10"));
+
+            context.Connection.RemoteIpAddress = null;
+            Assert.That(context.GetUserIpAddress(), Is.Null);
+        }
+
+        private sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+        {
+            public DateTimeOffset UtcNow { get; set; } = utcNow;
+
+            public override DateTimeOffset GetUtcNow() => UtcNow;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enforce five upload attempts per uploader per UTC day
- make admission atomic in SQL Server
- persist the forwarded client IP through Blazor prerendering for anonymous users
- add focused limiter and database coverage

## Validation
- app build passes
- upload limiter tests pass (4/4)
- SSDT database project builds