### PR TITLE
Make blob uploads lifecycle-safe

### DIFF
--- a/src/DokkanDaily/Components/Pages/Clears.razor
+++ b/src/DokkanDaily/Components/Pages/Clears.razor
@@ -129,6 +129,13 @@
                         if (invalidResult) continue;
                     }
 
+                    bool finalized = metadata.Value.Metadata.TryGetValue(AzureConstants.UPLOAD_STATUS_TAG, out string uploadStatus)
+                        ? uploadStatus == AzureConstants.UPLOAD_STATUS_VALID
+                        : metadata.Value.Metadata.ContainsKey(AzureConstants.CLEAR_TIME_TAG)
+                            && metadata.Value.Metadata.ContainsKey(AzureConstants.ITEMLESS_TAG);
+
+                    if (!finalized) continue;
+
                     ret.Add(new()
                     {
                         FileName = f.Name,

--- a/src/DokkanDaily/Constants/AzureConstants.cs
+++ b/src/DokkanDaily/Constants/AzureConstants.cs
@@ -23,5 +23,15 @@
         public static string CHALLENGE_TARGET_TAG => "challengetarget";
 
         public static string DISCORD_ID => "discordid";
+
+        public const string USER_AGENT_TAG = "useragent";
+
+        public const string UPLOAD_STATUS_TAG = "uploadstatus";
+
+        public const string UPLOAD_STATUS_PENDING = "pending";
+
+        public const string UPLOAD_STATUS_VALID = "valid";
+
+        public const string UPLOAD_STATUS_INVALID = "invalid";
     }
 }

--- a/src/DokkanDaily/Helpers/DokkanDailyHelper.cs
+++ b/src/DokkanDaily/Helpers/DokkanDailyHelper.cs
@@ -10,12 +10,17 @@ namespace DokkanDaily.Helpers
 {
     public static partial class DokkanDailyHelper
     {
+        private const int MaxBlobNameLength = 200;
+
         #region Regex
         [GeneratedRegex("[^a-zA-Z0-9-]")]
         public static partial Regex AlphaNumericRegex();
 
         [GeneratedRegex(@"([UDO]BC\s?[\*\+]\s?).*")]
         public static partial Regex DbcNicknameTagRegex();
+
+        [GeneratedRegex("[^a-zA-Z0-9._-]")]
+        public static partial Regex UnsafeBlobNameCharRegex();
         #endregion
 
         #region Helper Functions
@@ -48,15 +53,19 @@ namespace DokkanDaily.Helpers
         public static bool TryParseDokkanTimeSpan(string value, out TimeSpan result)
             => TimeSpan.TryParseExact(value, "h\\'mm\\\"ss\\.f", System.Globalization.CultureInfo.InvariantCulture, out result);
 
-        public static string AddUserAgentToFileName(string file, string userAgent)
+        public static string GetUserBlobPrefix(string discordId)
+            => string.IsNullOrWhiteSpace(discordId) ? null : $"{AlphaNumericRegex().Replace(discordId, "")}/";
+
+        public static string BuildBlobName(string userFileName, string discordId)
         {
-            if (string.IsNullOrEmpty(userAgent)) return file;
+            string leafName = Path.GetFileName((userFileName ?? "").Replace('\\', '/'));
+            string ext = UnsafeBlobNameCharRegex().Replace(Path.GetExtension(leafName), "");
+            string name = UnsafeBlobNameCharRegex().Replace(Path.GetFileNameWithoutExtension(leafName), "").Trim('.');
 
-            string ext = Path.GetExtension(file);
-            string name = Path.GetFileNameWithoutExtension(file);
-            string agentPart = string.IsNullOrEmpty(userAgent) ? "" : $"-{AlphaNumericRegex().Replace(userAgent, "")}";
+            if (string.IsNullOrWhiteSpace(name)) name = "clear";
+            if (name.Length > MaxBlobNameLength) name = name[..MaxBlobNameLength];
 
-            return $"{name}{agentPart}{ext}";
+            return $"{GetUserBlobPrefix(discordId)}{name}-{Guid.NewGuid():N}{ext}";
         }
 
         public static Unit GetUnit(string name, string title)

--- a/src/DokkanDaily/Services/AzureBlobService.cs
+++ b/src/DokkanDaily/Services/AzureBlobService.cs
@@ -2,6 +2,7 @@
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
+using System.Collections.Concurrent;
 using DokkanDaily.Configuration;
 using DokkanDaily.Constants;
 using DokkanDaily.Exceptions;
@@ -22,6 +23,9 @@ namespace DokkanDaily.Services
         private readonly IUploadAttemptLimiter _uploadAttemptLimiter;
         private readonly string _connectionString;
         private readonly string _containerName;
+
+        private static readonly SemaphoreSlim _ocrThrottle = new(Math.Max(1, Environment.ProcessorCount / 2));
+        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _uploaderLocks = new();
 
         private const int maxFileSize = 1024 * 8192;
 
@@ -48,47 +52,76 @@ namespace DokkanDaily.Services
             if (!admission.Accepted)
                 throw new UploadRejectedException(admission.RejectionMessage);
 
+            SemaphoreSlim uploaderLock = string.IsNullOrWhiteSpace(discordId)
+                ? null
+                : _uploaderLocks.GetOrAdd(discordId, _ => new SemaphoreSlim(1, 1));
+            bool uploaderLockHeld = false;
+            MemoryStream uploadStream = null;
+
             try
             {
+                if (uploaderLock != null)
+                {
+                    await uploaderLock.WaitAsync();
+                    uploaderLockHeld = true;
+                }
+
                 var (container, _) = await GetOrCreate(bucket);
 
-                string fileName = DokkanDailyHelper.AddUserAgentToFileName(userFileName, userAgent);
+                string fileName = DokkanDailyHelper.BuildBlobName(userFileName, discordId);
 
                 BlobClient blob = container.GetBlobClient(fileName);
 
-                await blob.DeleteIfExistsAsync(DeleteSnapshotsOption.IncludeSnapshots);
-
-                MemoryStream ms = new();
+                uploadStream = new MemoryStream();
                 using Stream fileStream = browserFile.OpenReadStream(maxFileSize);
-                await fileStream.CopyToAsync(ms);
-                ms.Position = 0;
+                await fileStream.CopyToAsync(uploadStream);
+                uploadStream.Position = 0;
 
                 _logger.LogInformation("Uploading to `{Container}/{File}`...", container.Name, fileName);
 
-                await blob.UploadAsync(ms, options: new BlobUploadOptions()
+                await blob.UploadAsync(uploadStream, options: new BlobUploadOptions()
                 {
                     HttpHeaders = new BlobHttpHeaders { ContentType = contentType },
-                    Tags = new Dictionary<string, string> { { AzureConstants.DATE_TAG, DokkanDailyHelper.GetUtcNowDateTag() } }
+                    Tags = new Dictionary<string, string> { { AzureConstants.DATE_TAG, DokkanDailyHelper.GetUtcNowDateTag() } },
+                    Metadata = BuildIdentityTagDict(model, discordUsername, discordId, remoteIp, userAgent)
                 });
 
                 _logger.LogInformation("Finished Azure upload.");
 
-                // do OCR analysis, dont block the main thread
+                MemoryStream analysisStream = uploadStream;
+                bool releaseUploaderLock = uploaderLockHeld;
+
                 _ = Task.Run(async () =>
                 {
+                    bool throttleHeld = false;
                     try
                     {
-                        var metadata = _ocrService.ProcessImage(ms);
+                        await _ocrThrottle.WaitAsync();
+                        throttleHeld = true;
+
+                        var metadata = _ocrService.ProcessImage(analysisStream);
                         _logger.LogInformation("Finished processing image.");
-                        var tags = BuildTagDict(model, metadata, discordUsername, discordId, remoteIp);
+                        var tags = BuildTagDict(model, metadata, discordUsername, discordId, remoteIp, userAgent);
                         await blob.SetMetadataAsync(tags);
                         _logger.LogInformation("Finished updating Azure metadata.");
+
+                        if (metadata != null)
+                            await DeletePreviousUploads(container, blob, discordId);
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Unhandled exception in background OCR task");
                     }
+                    finally
+                    {
+                        if (throttleHeld) _ocrThrottle.Release();
+                        if (releaseUploaderLock) uploaderLock.Release();
+                        await analysisStream.DisposeAsync();
+                    }
                 });
+
+                uploadStream = null;
+                uploaderLockHeld = false;
 
                 return blob;
             }
@@ -96,6 +129,11 @@ namespace DokkanDaily.Services
             {
                 _logger.LogError(ex, "Unhandled exception while uploading to Azure");
                 throw;
+            }
+            finally
+            {
+                if (uploaderLockHeld) uploaderLock.Release();
+                if (uploadStream != null) await uploadStream.DisposeAsync();
             }
         }
 
@@ -234,33 +272,75 @@ namespace DokkanDaily.Services
             }
         }
 
-        private static Dictionary<string, string> BuildTagDict(Challenge model, ClearMetadata metadata, string discordUsername, string discordId, string remoteIp)
+        internal static Dictionary<string, string> BuildIdentityTagDict(Challenge model, string discordUsername, string discordId, string remoteIp, string userAgent)
         {
-            string invalid = null;
-            if (metadata == null) invalid = true.ToString();
-
             var dict = new Dictionary<string, string>()
             {
                 { AzureConstants.DAILY_TYPE_TAG, model.DailyType.ToString()},
-                { AzureConstants.EVENT_TAG, model.TodaysEvent.FullName},
-                { AzureConstants.USER_NAME_TAG, metadata?.Nickname?.EscapeUnicode()},
-                { AzureConstants.ITEMLESS_TAG, (metadata?.ItemlessClear)?.ToString()},
-                { AzureConstants.CLEAR_TIME_TAG, metadata?.ClearTime},
-                { AzureConstants.DISCORD_NAME_TAG, discordUsername },
+                { AzureConstants.EVENT_TAG, model.TodaysEvent.FullName?.EscapeUnicode()},
+                { AzureConstants.DISCORD_NAME_TAG, discordUsername?.EscapeUnicode() },
                 { AzureConstants.DISCORD_ID,  discordId },
-                { AzureConstants.INVALID_TAG, invalid },
                 { AzureConstants.IP_TAG, remoteIp },
-                { AzureConstants.CHALLENGE_TARGET_TAG, model.DailyType switch
+                { AzureConstants.USER_AGENT_TAG, userAgent?.EscapeUnicode() },
+                { AzureConstants.UPLOAD_STATUS_TAG, AzureConstants.UPLOAD_STATUS_PENDING },
+                { AzureConstants.CHALLENGE_TARGET_TAG, (model.DailyType switch
                     {
                         DailyType.LinkSkill =>  model.LinkSkill.Name,
                         DailyType.Category => model.Category.Name,
                         DailyType.Character => model.Leader.FullName,
                         _ => null
-                    }
+                    })?.EscapeUnicode()
                 }
             };
 
             return dict.Where(kv => !string.IsNullOrEmpty(kv.Value)).ToDictionary();
+        }
+
+        private static Dictionary<string, string> BuildTagDict(Challenge model, ClearMetadata metadata, string discordUsername, string discordId, string remoteIp, string userAgent)
+        {
+            Dictionary<string, string> dict = BuildIdentityTagDict(model, discordUsername, discordId, remoteIp, userAgent);
+
+            if (metadata == null)
+            {
+                dict[AzureConstants.UPLOAD_STATUS_TAG] = AzureConstants.UPLOAD_STATUS_INVALID;
+                dict[AzureConstants.INVALID_TAG] = true.ToString();
+                return dict;
+            }
+
+            dict[AzureConstants.UPLOAD_STATUS_TAG] = AzureConstants.UPLOAD_STATUS_VALID;
+            dict[AzureConstants.USER_NAME_TAG] = metadata.Nickname?.EscapeUnicode();
+            dict[AzureConstants.ITEMLESS_TAG] = metadata.ItemlessClear.ToString();
+            dict[AzureConstants.CLEAR_TIME_TAG] = metadata.ClearTime;
+
+            return dict.Where(kv => !string.IsNullOrEmpty(kv.Value)).ToDictionary();
+        }
+
+        private async Task DeletePreviousUploads(BlobContainerClient container, BlobClient replacement, string discordId)
+        {
+            string prefix = DokkanDailyHelper.GetUserBlobPrefix(discordId);
+            if (prefix == null) return;
+
+            try
+            {
+                DateTimeOffset? replacementCreatedOn = (await replacement.GetPropertiesAsync()).Value.CreatedOn;
+                if (replacementCreatedOn == null) return;
+
+                await foreach (BlobItem existing in container.GetBlobsAsync(BlobTraits.None, BlobStates.None, prefix, CancellationToken.None))
+                {
+                    if (existing.Name == replacement.Name ||
+                        existing.Properties.CreatedOn == null ||
+                        existing.Properties.CreatedOn >= replacementCreatedOn)
+                    {
+                        continue;
+                    }
+
+                    await container.DeleteBlobIfExistsAsync(existing.Name, DeleteSnapshotsOption.IncludeSnapshots);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not remove prior uploads for Discord user `{DiscordId}`.", discordId);
+            }
         }
 
         private async Task<(BlobContainerClient, bool)> GetOrCreate(string bucket)

--- a/tests/DokkanDailyTests/HelperTests.cs
+++ b/tests/DokkanDailyTests/HelperTests.cs
@@ -1,6 +1,7 @@
 ﻿using DokkanDaily.Constants;
 using DokkanDaily.Helpers;
 using DokkanDaily.Models;
+using DokkanDaily.Models.Enums;
 using DokkanDaily.Services;
 
 namespace DokkanDailyTests
@@ -9,21 +10,57 @@ namespace DokkanDailyTests
     public class HelperTests
     {
         [Test]
-        [TestCase("aliens.png", "/Agent 47/", "aliens-Agent47.png")]
-        [TestCase("IMG_1907.png", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0", "IMG_1907-Mozilla50WindowsNT100Win64x64rv1300Gecko20100101Firefox1300.png")]
-        [TestCase("myFile.LongName.WithDots.pdf", "idk/1.0 how; a; user agent; works", "myFile.LongName.WithDots-idk10howauseragentworks.pdf")]
-        [TestCase("cats.jpg", "", "cats.jpg")]
-        public void CanAddAgentToFileName(string file, string agent, string result)
+        [TestCase("cats.png", null, @"^cats-[0-9a-f]{32}\.png$")]
+        [TestCase("../../escape.png", null, @"^escape-[0-9a-f]{32}\.png$")]
+        [TestCase(@"..\..\windows\c.png", null, @"^c-[0-9a-f]{32}\.png$")]
+        [TestCase("cats.png", "112089455933792256", @"^112089455933792256/cats-[0-9a-f]{32}\.png$")]
+        public void BlobNamesAreSanitizedUniqueAndScopedToTheUploader(string file, string discordId, string expected)
         {
-            string output = DokkanDailyHelper.AddUserAgentToFileName(file, agent);
+            string output = DokkanDailyHelper.BuildBlobName(file, discordId);
 
-            Assert.That(output, Is.EqualTo(result));
+            Assert.That(output, Does.Match(expected));
         }
 
         [Test]
-        public void NullAgentWorks()
+        public void BlobNamesNeverEscapeTheOwnerDirectory()
         {
-            Assert.That(DokkanDailyHelper.AddUserAgentToFileName("cats.png", null), Is.EqualTo("cats.png"));
+            string output = DokkanDailyHelper.BuildBlobName("../../../other-user/steal.png", "42");
+
+            Assert.That(output, Does.StartWith("42/"));
+            Assert.That(output, Does.Not.Contain(".."));
+        }
+
+        [Test]
+        public void BlobNamesAreUniquePerUpload()
+        {
+            string first = DokkanDailyHelper.BuildBlobName("clear.png", "42");
+            string second = DokkanDailyHelper.BuildBlobName("clear.png", "42");
+
+            Assert.That(first, Is.Not.EqualTo(second));
+        }
+
+        [Test]
+        public void InitialBlobMetadataIsAsciiSafe()
+        {
+            Challenge challenge = new(
+                DailyType.Character,
+                new Stage("Event", Tier.S, "event"),
+                null,
+                null,
+                new Leader("Power of Rosé", "Gokū Black", Tier.S),
+                null,
+                DateTime.UtcNow);
+
+            Dictionary<string, string> metadata = AzureBlobService.BuildIdentityTagDict(
+                challenge,
+                "Coopér",
+                "42",
+                "127.0.0.1",
+                "Bröwser");
+
+            Assert.That(metadata.Values.All(value => value.All(character => character <= 127)), Is.True);
+            Assert.That(metadata[AzureConstants.CHALLENGE_TARGET_TAG], Does.Contain(@"\u00e9"));
+            Assert.That(metadata[AzureConstants.UPLOAD_STATUS_TAG], Is.EqualTo(AzureConstants.UPLOAD_STATUS_PENDING));
         }
 
 


### PR DESCRIPTION
## Summary
- use unique, sanitized, uploader-scoped blob names
- mark uploads pending until OCR finishes, then valid or invalid
- make all blob metadata ASCII-safe
- bound OCR concurrency and replace prior authenticated uploads only after successful analysis
- hide unfinished uploads from the clears gallery

## Validation
- app build passes
- helper and blob metadata tests pass (30/30)