### PR TITLE
Finalize clears safely during reset

### DIFF
--- a/src/DokkanDaily/Constants/InternalConstants.cs
+++ b/src/DokkanDaily/Constants/InternalConstants.cs
@@ -27,5 +27,7 @@ namespace DokkanDaily.Constants
         public static DateTime Season1StartDate => new(2025, 1, 1);
 
         public static int ChallengeRepeatLimitDays => 7;
+
+        public static TimeSpan PendingOcrDrainTimeout => TimeSpan.FromSeconds(45);
     }
 }

--- a/src/DokkanDaily/Constants/InternalConstants.cs
+++ b/src/DokkanDaily/Constants/InternalConstants.cs
@@ -28,6 +28,6 @@ namespace DokkanDaily.Constants
 
         public static int ChallengeRepeatLimitDays => 7;
 
-        public static TimeSpan PendingOcrDrainTimeout => TimeSpan.FromSeconds(45);
+        public static TimeSpan PendingOcrWaitLogInterval => TimeSpan.FromSeconds(45);
     }
 }

--- a/src/DokkanDaily/Services/AzureBlobService.cs
+++ b/src/DokkanDaily/Services/AzureBlobService.cs
@@ -25,6 +25,7 @@ namespace DokkanDaily.Services
         private readonly string _containerName;
 
         private static readonly SemaphoreSlim _ocrThrottle = new(Math.Max(1, Environment.ProcessorCount / 2));
+        private static readonly ConcurrentDictionary<Guid, Task> _pendingAnalysis = new();
         private static readonly ConcurrentDictionary<string, SemaphoreSlim> _uploaderLocks = new();
 
         private const int maxFileSize = 1024 * 8192;
@@ -48,18 +49,23 @@ namespace DokkanDaily.Services
 
         public async Task<BlobClient> UploadToAzureAsync(string userFileName, string contentType, IBrowserFile browserFile, Challenge model, string bucket = null, string userAgent = null, string discordUsername = null, string discordId = null, string remoteIp = null)
         {
-            UploadAdmission admission = await _uploadAttemptLimiter.TryAcceptAsync(discordId, remoteIp);
-            if (!admission.Accepted)
-                throw new UploadRejectedException(admission.RejectionMessage);
+            Guid analysisId = Guid.NewGuid();
+            TaskCompletionSource analysisLifecycle = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            _pendingAnalysis[analysisId] = analysisLifecycle.Task;
 
             SemaphoreSlim uploaderLock = string.IsNullOrWhiteSpace(discordId)
                 ? null
                 : _uploaderLocks.GetOrAdd(discordId, _ => new SemaphoreSlim(1, 1));
             bool uploaderLockHeld = false;
+            bool lifecycleHandedToAnalysis = false;
             MemoryStream uploadStream = null;
 
             try
             {
+                UploadAdmission admission = await _uploadAttemptLimiter.TryAcceptAsync(discordId, remoteIp);
+                if (!admission.Accepted)
+                    throw new UploadRejectedException(admission.RejectionMessage);
+
                 if (uploaderLock != null)
                 {
                     await uploaderLock.WaitAsync();
@@ -116,14 +122,26 @@ namespace DokkanDaily.Services
                     {
                         if (throttleHeld) _ocrThrottle.Release();
                         if (releaseUploaderLock) uploaderLock.Release();
-                        await analysisStream.DisposeAsync();
+                        try
+                        {
+                            await analysisStream.DisposeAsync();
+                        }
+                        finally
+                        {
+                            CompletePendingAnalysis(analysisId, analysisLifecycle);
+                        }
                     }
                 });
 
                 uploadStream = null;
                 uploaderLockHeld = false;
+                lifecycleHandedToAnalysis = true;
 
                 return blob;
+            }
+            catch (UploadRejectedException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -134,7 +152,41 @@ namespace DokkanDaily.Services
             {
                 if (uploaderLockHeld) uploaderLock.Release();
                 if (uploadStream != null) await uploadStream.DisposeAsync();
+                if (!lifecycleHandedToAnalysis) CompletePendingAnalysis(analysisId, analysisLifecycle);
             }
+        }
+
+        public async Task WaitForPendingAnalysis(TimeSpan timeout)
+        {
+            DateTimeOffset deadline = DateTimeOffset.UtcNow.Add(timeout);
+
+            while (true)
+            {
+                Task[] pending = [.. _pendingAnalysis.Values];
+                if (pending.Length == 0) return;
+
+                TimeSpan remaining = deadline - DateTimeOffset.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    _logger.LogWarning("Timed out waiting for OCR to finish. {Count} clear(s) remain pending and will be skipped.", _pendingAnalysis.Count);
+                    return;
+                }
+
+                _logger.LogInformation("Waiting up to {Timeout} for {Count} in-flight OCR task(s) to finish.", remaining, pending.Length);
+
+                Task all = Task.WhenAll(pending);
+                if (await Task.WhenAny(all, Task.Delay(remaining)) != all)
+                {
+                    _logger.LogWarning("Timed out waiting for OCR to finish. {Count} clear(s) remain pending and will be skipped.", _pendingAnalysis.Count);
+                    return;
+                }
+            }
+        }
+
+        private static void CompletePendingAnalysis(Guid analysisId, TaskCompletionSource lifecycle)
+        {
+            lifecycle.TrySetResult();
+            _pendingAnalysis.TryRemove(analysisId, out _);
         }
 
         // TODO: test this

--- a/src/DokkanDaily/Services/AzureBlobService.cs
+++ b/src/DokkanDaily/Services/AzureBlobService.cs
@@ -20,25 +20,29 @@ namespace DokkanDaily.Services
         private readonly DokkanDailySettings _settings;
         private readonly ILogger<AzureBlobService> _logger;
         private readonly IOcrService _ocrService;
+        private readonly IRngHelperService _rngHelperService;
         private readonly IUploadAttemptLimiter _uploadAttemptLimiter;
         private readonly string _connectionString;
         private readonly string _containerName;
 
         private static readonly SemaphoreSlim _ocrThrottle = new(Math.Max(1, Environment.ProcessorCount / 2));
         private static readonly ConcurrentDictionary<Guid, Task> _pendingAnalysis = new();
-        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _uploaderLocks = new();
+        private static readonly SemaphoreSlim _resetBarrier = new(1, 1);
 
         private const int maxFileSize = 1024 * 8192;
+        private const string ResetInProgressMessage = "Daily results are being calculated. Please try your upload again shortly";
+        private const string ChallengeChangedMessage = "The daily challenge changed while this page was open. Refresh the page and try again";
 
         private string TodaysBucketFullName => GetBucketNameForDate(DokkanDailyHelper.GetUtcNowDateTag());
 
-        public AzureBlobService(IOptions<DokkanDailySettings> settings, ILogger<AzureBlobService> logger, IOcrService ocrService, IUploadAttemptLimiter uploadAttemptLimiter)
+        public AzureBlobService(IOptions<DokkanDailySettings> settings, ILogger<AzureBlobService> logger, IOcrService ocrService, IRngHelperService rngHelperService, IUploadAttemptLimiter uploadAttemptLimiter)
         {
             _settings = settings.Value;
             _logger = logger;
             _connectionString = _settings.AzureBlobConnectionString;
             _containerName = _settings.AzureBlobContainerName;
             _ocrService = ocrService;
+            _rngHelperService = rngHelperService;
             _uploadAttemptLimiter = uploadAttemptLimiter;
         }
 
@@ -51,26 +55,34 @@ namespace DokkanDaily.Services
         {
             Guid analysisId = Guid.NewGuid();
             TaskCompletionSource analysisLifecycle = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            _pendingAnalysis[analysisId] = analysisLifecycle.Task;
-
-            SemaphoreSlim uploaderLock = string.IsNullOrWhiteSpace(discordId)
-                ? null
-                : _uploaderLocks.GetOrAdd(discordId, _ => new SemaphoreSlim(1, 1));
-            bool uploaderLockHeld = false;
+            bool lifecycleRegistered = false;
             bool lifecycleHandedToAnalysis = false;
             MemoryStream uploadStream = null;
 
             try
             {
+                if (!await _resetBarrier.WaitAsync(0))
+                    throw new UploadRejectedException(ResetInProgressMessage);
+
+                try
+                {
+                    _pendingAnalysis[analysisId] = analysisLifecycle.Task;
+                    lifecycleRegistered = true;
+                }
+                finally
+                {
+                    _resetBarrier.Release();
+                }
+
+                Challenge currentChallenge = await _rngHelperService.GetDailyChallenge();
+                if (model is null || currentChallenge is null || model.Date != currentChallenge.Date)
+                    throw new UploadRejectedException(ChallengeChangedMessage);
+
+                model = currentChallenge;
+
                 UploadAdmission admission = await _uploadAttemptLimiter.TryAcceptAsync(discordId, remoteIp);
                 if (!admission.Accepted)
                     throw new UploadRejectedException(admission.RejectionMessage);
-
-                if (uploaderLock != null)
-                {
-                    await uploaderLock.WaitAsync();
-                    uploaderLockHeld = true;
-                }
 
                 var (container, _) = await GetOrCreate(bucket);
 
@@ -95,7 +107,6 @@ namespace DokkanDaily.Services
                 _logger.LogInformation("Finished Azure upload.");
 
                 MemoryStream analysisStream = uploadStream;
-                bool releaseUploaderLock = uploaderLockHeld;
 
                 _ = Task.Run(async () =>
                 {
@@ -110,9 +121,6 @@ namespace DokkanDaily.Services
                         var tags = BuildTagDict(model, metadata, discordUsername, discordId, remoteIp, userAgent);
                         await blob.SetMetadataAsync(tags);
                         _logger.LogInformation("Finished updating Azure metadata.");
-
-                        if (metadata != null)
-                            await DeletePreviousUploads(container, blob, discordId);
                     }
                     catch (Exception ex)
                     {
@@ -121,7 +129,6 @@ namespace DokkanDaily.Services
                     finally
                     {
                         if (throttleHeld) _ocrThrottle.Release();
-                        if (releaseUploaderLock) uploaderLock.Release();
                         try
                         {
                             await analysisStream.DisposeAsync();
@@ -134,7 +141,6 @@ namespace DokkanDaily.Services
                 });
 
                 uploadStream = null;
-                uploaderLockHeld = false;
                 lifecycleHandedToAnalysis = true;
 
                 return blob;
@@ -150,35 +156,34 @@ namespace DokkanDaily.Services
             }
             finally
             {
-                if (uploaderLockHeld) uploaderLock.Release();
                 if (uploadStream != null) await uploadStream.DisposeAsync();
-                if (!lifecycleHandedToAnalysis) CompletePendingAnalysis(analysisId, analysisLifecycle);
+                if (lifecycleRegistered && !lifecycleHandedToAnalysis)
+                    CompletePendingAnalysis(analysisId, analysisLifecycle);
             }
         }
 
-        public async Task WaitForPendingAnalysis(TimeSpan timeout)
+        public async Task<IAsyncDisposable> AcquireResetBarrierAsync()
         {
-            DateTimeOffset deadline = DateTimeOffset.UtcNow.Add(timeout);
+            await _resetBarrier.WaitAsync();
+            return new ResetBarrierLease(_resetBarrier);
+        }
+
+        public async Task WaitForPendingAnalysis(TimeSpan warningInterval)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(warningInterval, TimeSpan.Zero);
 
             while (true)
             {
                 Task[] pending = [.. _pendingAnalysis.Values];
                 if (pending.Length == 0) return;
 
-                TimeSpan remaining = deadline - DateTimeOffset.UtcNow;
-                if (remaining <= TimeSpan.Zero)
-                {
-                    _logger.LogWarning("Timed out waiting for OCR to finish. {Count} clear(s) remain pending and will be skipped.", _pendingAnalysis.Count);
-                    return;
-                }
-
-                _logger.LogInformation("Waiting up to {Timeout} for {Count} in-flight OCR task(s) to finish.", remaining, pending.Length);
+                _logger.LogInformation("Waiting for {Count} in-flight OCR task(s) to finish.", pending.Length);
 
                 Task all = Task.WhenAll(pending);
-                if (await Task.WhenAny(all, Task.Delay(remaining)) != all)
+                if (await Task.WhenAny(all, Task.Delay(warningInterval)) != all)
                 {
-                    _logger.LogWarning("Timed out waiting for OCR to finish. {Count} clear(s) remain pending and will be skipped.", _pendingAnalysis.Count);
-                    return;
+                    _logger.LogWarning("OCR is still running after {Interval}. Continuing to wait for {Count} clear(s) so they are not skipped.", warningInterval, _pendingAnalysis.Count);
+                    continue;
                 }
             }
         }
@@ -367,34 +372,6 @@ namespace DokkanDaily.Services
             return dict.Where(kv => !string.IsNullOrEmpty(kv.Value)).ToDictionary();
         }
 
-        private async Task DeletePreviousUploads(BlobContainerClient container, BlobClient replacement, string discordId)
-        {
-            string prefix = DokkanDailyHelper.GetUserBlobPrefix(discordId);
-            if (prefix == null) return;
-
-            try
-            {
-                DateTimeOffset? replacementCreatedOn = (await replacement.GetPropertiesAsync()).Value.CreatedOn;
-                if (replacementCreatedOn == null) return;
-
-                await foreach (BlobItem existing in container.GetBlobsAsync(BlobTraits.None, BlobStates.None, prefix, CancellationToken.None))
-                {
-                    if (existing.Name == replacement.Name ||
-                        existing.Properties.CreatedOn == null ||
-                        existing.Properties.CreatedOn >= replacementCreatedOn)
-                    {
-                        continue;
-                    }
-
-                    await container.DeleteBlobIfExistsAsync(existing.Name, DeleteSnapshotsOption.IncludeSnapshots);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Could not remove prior uploads for Discord user `{DiscordId}`.", discordId);
-            }
-        }
-
         private async Task<(BlobContainerClient, bool)> GetOrCreate(string bucket)
         {
             bool created = false;
@@ -412,6 +389,17 @@ namespace DokkanDaily.Services
             }
 
             return (container, created);
+        }
+
+        private sealed class ResetBarrierLease(SemaphoreSlim resetBarrier) : IAsyncDisposable
+        {
+            private SemaphoreSlim _resetBarrier = resetBarrier;
+
+            public ValueTask DisposeAsync()
+            {
+                Interlocked.Exchange(ref _resetBarrier, null)?.Release();
+                return ValueTask.CompletedTask;
+            }
         }
     }
 }

--- a/src/DokkanDaily/Services/Interfaces/IAzureBlobService.cs
+++ b/src/DokkanDaily/Services/Interfaces/IAzureBlobService.cs
@@ -12,7 +12,9 @@ namespace DokkanDaily.Services.Interfaces
 
         Task<int> GetFileCountForTag(string tagName, string bucket = null);
 
-        Task WaitForPendingAnalysis(TimeSpan timeout);
+        Task<IAsyncDisposable> AcquireResetBarrierAsync();
+
+        Task WaitForPendingAnalysis(TimeSpan warningInterval);
 
         string GetBlobSasTokenByFile(string fileName, string bucket = null);
 

--- a/src/DokkanDaily/Services/Interfaces/IAzureBlobService.cs
+++ b/src/DokkanDaily/Services/Interfaces/IAzureBlobService.cs
@@ -12,6 +12,8 @@ namespace DokkanDaily.Services.Interfaces
 
         Task<int> GetFileCountForTag(string tagName, string bucket = null);
 
+        Task WaitForPendingAnalysis(TimeSpan timeout);
+
         string GetBlobSasTokenByFile(string fileName, string bucket = null);
 
         Task PruneContainers(int daysToKeep);

--- a/src/DokkanDaily/Services/ResetService.cs
+++ b/src/DokkanDaily/Services/ResetService.cs
@@ -31,6 +31,10 @@ namespace DokkanDaily.Services
         {
             _logger.LogInformation("Starting daily reset...");
 
+            // Registering an upload and entering reset are mutually exclusive. Once this lease is
+            // held, new uploads are rejected until every registered analysis has been scored.
+            await using IAsyncDisposable resetBarrier = await _azureBlobService.AcquireResetBarrierAsync();
+
             // Capture this before draining OCR: a reset beginning just before midnight still owns
             // that day's bucket even if the remaining analysis crosses into the next UTC day.
             DateTime date = DateTime.UtcNow - TimeSpan.FromDays(daysAgo);
@@ -63,7 +67,7 @@ namespace DokkanDaily.Services
             if (!isAdhoc)
                 await _azureBlobService.PruneContainers(30);
 
-            await _azureBlobService.WaitForPendingAnalysis(InternalConstants.PendingOcrDrainTimeout);
+            await _azureBlobService.WaitForPendingAnalysis(InternalConstants.PendingOcrWaitLogInterval);
 
             // upload clears for the day
             string tag = date.GetTagFromDate();

--- a/src/DokkanDaily/Services/ResetService.cs
+++ b/src/DokkanDaily/Services/ResetService.cs
@@ -31,6 +31,10 @@ namespace DokkanDaily.Services
         {
             _logger.LogInformation("Starting daily reset...");
 
+            // Capture this before draining OCR: a reset beginning just before midnight still owns
+            // that day's bucket even if the remaining analysis crosses into the next UTC day.
+            DateTime date = DateTime.UtcNow - TimeSpan.FromDays(daysAgo);
+
             // get old challenge
             var todaysChallenge = await _rngHelperService.GetDailyChallenge();
 
@@ -56,10 +60,10 @@ namespace DokkanDaily.Services
                 }
             }
 
-            // delete old clears
-            await _azureBlobService.PruneContainers(30);
+            if (!isAdhoc)
+                await _azureBlobService.PruneContainers(30);
 
-            DateTime date = DateTime.UtcNow - TimeSpan.FromDays(daysAgo);
+            await _azureBlobService.WaitForPendingAnalysis(InternalConstants.PendingOcrDrainTimeout);
 
             // upload clears for the day
             string tag = date.GetTagFromDate();
@@ -74,6 +78,16 @@ namespace DokkanDaily.Services
                     var props = await clear.GetPropertiesAsync();
                     var tags = props.Value.Metadata;
 
+                    bool hasUploadStatus = tags.TryGetValue(AzureConstants.UPLOAD_STATUS_TAG, out string uploadStatus);
+                    bool finalized = hasUploadStatus
+                        ? string.Equals(uploadStatus, AzureConstants.UPLOAD_STATUS_VALID, StringComparison.OrdinalIgnoreCase)
+                        : tags.ContainsKey(AzureConstants.CLEAR_TIME_TAG) && tags.ContainsKey(AzureConstants.ITEMLESS_TAG);
+                    if (!finalized)
+                    {
+                        _logger.LogWarning("Upload is not finalized as valid ({Status}). Skipping clear.", hasUploadStatus ? uploadStatus : "legacy-incomplete");
+                        continue;
+                    }
+
                     // skip upload in case we don't know who the clear belongs to or it was marked invalid
                     if (tags.TryGetValue(AzureConstants.INVALID_TAG, out string invalid))
                     {
@@ -86,11 +100,12 @@ namespace DokkanDaily.Services
                         continue;
                     }
 
-                    if (!tags.TryGetValue(AzureConstants.ITEMLESS_TAG, out string itemless))
+                    if (!tags.TryGetValue(AzureConstants.ITEMLESS_TAG, out string itemless) || !bool.TryParse(itemless, out bool itemlessClear))
                     {
-                        _logger.LogWarning("`ITEMLESS` tag missing. Defaulting to false.");
+                        _logger.LogWarning("`ITEMLESS` tag missing or unparseable. Defaulting to false.");
+                        itemlessClear = false;
                     }
-                ;
+
                     if (!tags.TryGetValue(AzureConstants.CLEAR_TIME_TAG, out string clearTime) || !DokkanDailyHelper.TryParseDokkanTimeSpan(clearTime, out TimeSpan timeSpan))
                     {
                         _logger.LogWarning("`CLEARTIME` tag missing. Defaulting to TimeSpan.MaxValue.");
@@ -103,7 +118,7 @@ namespace DokkanDaily.Services
                         DiscordUsername = tags.TryGetValue(AzureConstants.DISCORD_NAME_TAG, out string discord) ? discord : null,
                         DiscordId = tags.TryGetValue(AzureConstants.DISCORD_ID, out string discordId) ? discordId : null,
                         ClearTime = clearTime,
-                        ItemlessClear = bool.Parse(itemless),
+                        ItemlessClear = itemlessClear,
                         ClearTimeSpan = timeSpan
                     });
                 }
@@ -113,7 +128,9 @@ namespace DokkanDaily.Services
                 }
             }
 
-            var dailyWinner = clears.MinBy(x => x.ClearTimeSpan);
+            DbClear dailyWinner = clears.Count == 1
+                ? clears[0]
+                : clears.Where(x => x.ClearTimeSpan != TimeSpan.MaxValue).MinBy(x => x.ClearTimeSpan);
             if (dailyWinner is not null) dailyWinner.IsDailyHighscore = true;
 
             _logger.LogInformation("Calculated {@Clear} to be the fastest today.", dailyWinner);
@@ -121,11 +138,22 @@ namespace DokkanDaily.Services
             try
             {
                 clears = clears
-                    .GroupBy(x => x.DokkanNickname)
+                    .GroupBy(GetIdentityKey)
                     .Select(group =>
-                        group.FirstOrDefault(x => x.IsDailyHighscore)
-                        ?? group.FirstOrDefault(x => x.ItemlessClear)
-                        ?? group.MinBy(x => x.ClearTimeSpan))
+                    {
+                        DbClear best = group.FirstOrDefault(x => x.IsDailyHighscore)
+                            ?? group.MinBy(x => x.ClearTimeSpan);
+                        return new DbClear
+                        {
+                            DokkanNickname = best.DokkanNickname,
+                            DiscordUsername = best.DiscordUsername,
+                            DiscordId = best.DiscordId,
+                            ItemlessClear = group.Any(x => x.ItemlessClear),
+                            ClearTime = best.ClearTime,
+                            IsDailyHighscore = best.IsDailyHighscore,
+                            ClearTimeSpan = best.ClearTimeSpan
+                        };
+                    })
                     .ToList();
 
                 await _repository.InsertDailyClears(clears, date);
@@ -143,6 +171,13 @@ namespace DokkanDaily.Services
             _logger.LogInformation("Leaderboard updated.");
 
             _logger.LogInformation("Reset completed with no critical errors.");
+        }
+
+        private static string GetIdentityKey(DbClear clear)
+        {
+            if (!string.IsNullOrWhiteSpace(clear.DiscordId)) return $"discordid:{clear.DiscordId}";
+            if (!string.IsNullOrWhiteSpace(clear.DiscordUsername)) return $"discord:{clear.DiscordUsername}";
+            return $"nickname:{clear.DokkanNickname}";
         }
 
         public async Task ProcessLeaderboard()

--- a/src/DokkanDailyDB/Core/StoredProcedures/ClearInsert.sql
+++ b/src/DokkanDailyDB/Core/StoredProcedures/ClearInsert.sql
@@ -1,55 +1,136 @@
-﻿CREATE PROCEDURE [Core].[ClearInsert]
+CREATE PROCEDURE [Core].[ClearInsert]
     @Clears Core.ClearType READONLY,
     @ClearDate DATETIME2(2)
 AS
 BEGIN
+    SET NOCOUNT ON;
+    SET XACT_ABORT ON;
 
-    -- todo: merge ('foo', null) and (null, 'bar') when receiving ('foo', 'bar')
+    BEGIN TRY
+        BEGIN TRANSACTION;
 
-    MERGE INTO Core.DokkanDailyUser AS TARGET
-    USING @Clears AS SOURCE
-    ON (SOURCE.DokkanNickname = TARGET.DokkanNickname OR SOURCE.DiscordUsername = TARGET.DiscordUsername)
-    WHEN MATCHED
-    THEN UPDATE 
-        SET TARGET.DokkanNickname = ISNULL(SOURCE.DokkanNickname, TARGET.DokkanNickname),
-        TARGET.DiscordUsername = ISNULL(SOURCE.DiscordUsername, TARGET.DiscordUsername),
-        TARGET.DiscordId = ISNULL(SOURCE.DiscordId, TARGET.DiscordId)
-    WHEN NOT MATCHED BY TARGET THEN
-        INSERT([DokkanNickname], [DiscordUsername], [DiscordId])
-        VALUES(SOURCE.[DokkanNickname], SOURCE.[DiscordUsername], SOURCE.[DiscordId]);
+        -- Reset is normally the only writer, so serializing this short operation is a cheap way
+        -- to make admin reruns and overlapping workers safe across application instances.
+        DECLARE @LockResult INT;
+        EXEC @LockResult = sys.sp_getapplock
+            @Resource = 'Core.ClearInsert',
+            @LockMode = 'Exclusive',
+            @LockOwner = 'Transaction',
+            @LockTimeout = 15000;
 
-    MERGE INTO Core.StageClear AS TARGET
-    USING (
-        SELECT 
-            DDU.DokkanDailyUserId,
+        IF @LockResult < 0
+            THROW 51000, 'Could not acquire the clear-insert lock.', 1;
+
+        DECLARE @Resolved TABLE (
+            DokkanNickname VARCHAR(50) NULL,
+            DiscordUsername VARCHAR(50) NULL,
+            DiscordId VARCHAR(50) NULL,
+            ItemlessClear BIT NOT NULL,
+            ClearTime VARCHAR(25) NOT NULL,
+            IsDailyHighscore BIT NOT NULL,
+            DokkanDailyUserId INT NULL
+        );
+
+        INSERT INTO @Resolved (DokkanNickname, DiscordUsername, DiscordId, ItemlessClear, ClearTime, IsDailyHighscore, DokkanDailyUserId)
+        SELECT
+            C.DokkanNickname,
+            C.DiscordUsername,
+            C.DiscordId,
             C.ItemlessClear,
             C.ClearTime,
-            @ClearDate AS ClearDate,
-            C.IsDailyHighscore 
-        FROM @Clears C 
-        INNER JOIN Core.DokkanDailyUser DDU ON
-         C.DokkanNickname = DDU.DokkanNickname
-         OR C.DiscordUsername = DDU.DiscordUsername
-    ) AS SOURCE
-    ON (SOURCE.DokkanDailyUserId = TARGET.DokkanDailyUserId AND SOURCE.ClearDate = TARGET.ClearDate)
-    WHEN NOT MATCHED BY TARGET THEN
-        INSERT(
-            [DokkanDailyUserId],
-            [ItemlessClear],
-            [ClearTime],
-            [ClearDate],
-            [IsDailyHighscore])
-        VALUES(
-            SOURCE.DokkanDailyUserId,
-            SOURCE.ItemlessClear,
-            SOURCE.ClearTime,
-            SOURCE.ClearDate,
-            SOURCE.IsDailyHighscore)
-     WHEN MATCHED THEN
-     UPDATE SET 
-         TARGET.ItemlessClear = SOURCE.ItemlessClear
-         , TARGET.ClearTime = SOURCE.ClearTime
-         , Target.IsDailyHighscore = SOURCE.IsDailyHighscore;
+            C.IsDailyHighscore,
+            M.DokkanDailyUserId
+        FROM @Clears C
+        OUTER APPLY (
+            SELECT TOP 1 DDU.DokkanDailyUserId
+            FROM Core.DokkanDailyUser DDU
+            WHERE (C.DiscordId IS NOT NULL AND DDU.DiscordId = C.DiscordId)
+               OR (C.DiscordId IS NOT NULL
+                   AND C.DiscordUsername IS NOT NULL
+                   AND DDU.DiscordId IS NULL
+                   AND DDU.DiscordUsername = C.DiscordUsername)
+               OR (C.DiscordId IS NULL
+                   AND C.DiscordUsername IS NOT NULL
+                   AND DDU.DiscordUsername = C.DiscordUsername)
+               OR (C.DiscordId IS NULL
+                   AND C.DokkanNickname IS NOT NULL
+                   AND DDU.DokkanNickname = C.DokkanNickname)
+            ORDER BY
+                CASE
+                    WHEN C.DiscordId IS NOT NULL AND DDU.DiscordId = C.DiscordId THEN 1
+                    WHEN C.DiscordId IS NOT NULL AND DDU.DiscordId IS NULL THEN 2
+                    WHEN C.DiscordUsername IS NOT NULL AND DDU.DiscordUsername = C.DiscordUsername THEN 3
+                    WHEN C.DokkanNickname IS NOT NULL AND DDU.DokkanNickname = C.DokkanNickname THEN 4
+                    ELSE 5
+                END,
+                DDU.DokkanDailyUserId
+        ) M;
 
-RETURN 0
+        UPDATE DDU
+        SET DDU.DokkanNickname = ISNULL(R.DokkanNickname, DDU.DokkanNickname),
+            DDU.DiscordUsername = ISNULL(R.DiscordUsername, DDU.DiscordUsername),
+            DDU.DiscordId = ISNULL(R.DiscordId, DDU.DiscordId)
+        FROM Core.DokkanDailyUser DDU
+        INNER JOIN @Resolved R ON R.DokkanDailyUserId = DDU.DokkanDailyUserId;
+
+        INSERT INTO Core.DokkanDailyUser ([DokkanNickname], [DiscordUsername], [DiscordId])
+        SELECT DISTINCT R.DokkanNickname, R.DiscordUsername, R.DiscordId
+        FROM @Resolved R
+        WHERE R.DokkanDailyUserId IS NULL;
+
+        UPDATE R
+        SET R.DokkanDailyUserId = M.DokkanDailyUserId
+        FROM @Resolved R
+        OUTER APPLY (
+            SELECT TOP 1 DDU.DokkanDailyUserId
+            FROM Core.DokkanDailyUser DDU
+            WHERE (R.DiscordId IS NOT NULL AND DDU.DiscordId = R.DiscordId)
+               OR (R.DiscordId IS NULL AND R.DiscordUsername IS NOT NULL AND DDU.DiscordUsername = R.DiscordUsername)
+               OR (R.DiscordId IS NULL AND R.DiscordUsername IS NULL AND DDU.DokkanNickname = R.DokkanNickname)
+            ORDER BY DDU.DokkanDailyUserId
+        ) M
+        WHERE R.DokkanDailyUserId IS NULL;
+
+        ;WITH Ranked AS (
+            SELECT
+                R.DokkanDailyUserId,
+                R.ClearTime,
+                R.IsDailyHighscore,
+                MAX(CAST(R.ItemlessClear AS INT)) OVER (PARTITION BY R.DokkanDailyUserId) AS AnyItemless,
+                ROW_NUMBER() OVER (
+                    PARTITION BY R.DokkanDailyUserId
+                    ORDER BY R.IsDailyHighscore DESC, R.ClearTime ASC) AS RowRank
+            FROM @Resolved R
+            WHERE R.DokkanDailyUserId IS NOT NULL
+        )
+        MERGE INTO Core.StageClear WITH (HOLDLOCK) AS TARGET
+        USING (
+            SELECT
+                DokkanDailyUserId,
+                CAST(AnyItemless AS BIT) AS ItemlessClear,
+                ClearTime,
+                @ClearDate AS ClearDate,
+                IsDailyHighscore
+            FROM Ranked
+            WHERE RowRank = 1
+        ) AS SOURCE
+        ON SOURCE.DokkanDailyUserId = TARGET.DokkanDailyUserId
+           AND SOURCE.ClearDate = TARGET.ClearDate
+        WHEN NOT MATCHED BY TARGET THEN
+            INSERT ([DokkanDailyUserId], [ItemlessClear], [ClearTime], [ClearDate], [IsDailyHighscore])
+            VALUES (SOURCE.DokkanDailyUserId, SOURCE.ItemlessClear, SOURCE.ClearTime, SOURCE.ClearDate, SOURCE.IsDailyHighscore)
+        WHEN MATCHED THEN
+            UPDATE SET
+                TARGET.ItemlessClear = SOURCE.ItemlessClear,
+                TARGET.ClearTime = SOURCE.ClearTime,
+                TARGET.IsDailyHighscore = SOURCE.IsDailyHighscore;
+
+        COMMIT TRANSACTION;
+    END TRY
+    BEGIN CATCH
+        IF XACT_STATE() <> 0 ROLLBACK TRANSACTION;
+        THROW;
+    END CATCH
+
+    RETURN 0;
 END

--- a/src/DokkanDailyDB/Core/Tables/StageClear.sql
+++ b/src/DokkanDailyDB/Core/Tables/StageClear.sql
@@ -7,5 +7,6 @@
     [ClearTime] VARCHAR(25) NOT NULL,
     [ClearDate] DATETIME2(2) NOT NULL,
     CONSTRAINT [ClearPK] PRIMARY KEY CLUSTERED ([StageClearId] ASC),
-    CONSTRAINT [Clear_FK01] FOREIGN KEY ([DokkanDailyUserId]) REFERENCES [Core].[DokkanDailyUser]([DokkanDailyUserId])
+    CONSTRAINT [Clear_FK01] FOREIGN KEY ([DokkanDailyUserId]) REFERENCES [Core].[DokkanDailyUser]([DokkanDailyUserId]),
+    CONSTRAINT [StageClear_UC01] UNIQUE ([DokkanDailyUserId], [ClearDate])
 )

--- a/src/DokkanDailyDB/DokkanDailyDB.sqlproj
+++ b/src/DokkanDailyDB/DokkanDailyDB.sqlproj
@@ -64,13 +64,17 @@
     <Folder Include="RefData" />
     <Folder Include="Post-Deployment\" />
     <Folder Include="Post-Deployment\Scripts\" />
+    <Folder Include="Pre-Deployment\" />
+    <Folder Include="Pre-Deployment\Scripts\" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="Core\Tables\DokkanDailyUser.sql" />
     <Build Include="Core\Tables\StageClear.sql" />
     <Build Include="Security\Schemas.sql" />
     <Build Include="Core\UserDefinedTypes\ClearType.sql" />
-    <Build Include="Core\StoredProcedures\ClearInsert.sql" />
+    <Build Include="Core\StoredProcedures\ClearInsert.sql">
+      <SuppressTSqlWarnings>71502</SuppressTSqlWarnings>
+    </Build>
     <Build Include="Core\StoredProcedures\HallOfFameLeaderboardGet.sql" />
     <Build Include="Core\Tables\DailyChallenge.sql" />
     <Build Include="Core\StoredProcedures\DailyInsert.sql" />
@@ -86,5 +90,8 @@
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Post-Deployment\Scripts\PostDeployment.sql" />
+  </ItemGroup>
+  <ItemGroup>
+    <PreDeploy Include="Pre-Deployment\Scripts\PreDeployment.sql" />
   </ItemGroup>
 </Project>

--- a/src/DokkanDailyDB/Pre-Deployment/Scripts/PreDeployment.sql
+++ b/src/DokkanDailyDB/Pre-Deployment/Scripts/PreDeployment.sql
@@ -1,6 +1,35 @@
 /* Remove historical duplicates before the one-clear-per-user-per-day constraint is applied. */
 IF OBJECT_ID('Core.StageClear', 'U') IS NOT NULL
 BEGIN
+    DECLARE @MergedClears TABLE
+    (
+        KeeperStageClearId INT NOT NULL,
+        DokkanDailyUserId INT NOT NULL,
+        ClearDate DATETIME2(2) NOT NULL,
+        ItemlessClear BIT NOT NULL,
+        IsDailyHighscore BIT NOT NULL,
+        ClearTime VARCHAR(25) NOT NULL
+    );
+
+    INSERT INTO @MergedClears
+        (KeeperStageClearId, DokkanDailyUserId, ClearDate, ItemlessClear, IsDailyHighscore, ClearTime)
+    SELECT
+        MAX(StageClearId),
+        DokkanDailyUserId,
+        ClearDate,
+        CAST(MAX(CAST(ItemlessClear AS TINYINT)) AS BIT),
+        CAST(MAX(CAST(IsDailyHighscore AS TINYINT)) AS BIT),
+        MIN(ClearTime)
+    FROM Core.StageClear WITH (TABLOCKX, HOLDLOCK)
+    GROUP BY DokkanDailyUserId, ClearDate;
+
+    UPDATE C
+    SET C.ItemlessClear = M.ItemlessClear,
+        C.IsDailyHighscore = M.IsDailyHighscore,
+        C.ClearTime = M.ClearTime
+    FROM Core.StageClear C
+    INNER JOIN @MergedClears M ON M.KeeperStageClearId = C.StageClearId;
+
     ;WITH DuplicateClears AS (
         SELECT
             StageClearId,

--- a/src/DokkanDailyDB/Pre-Deployment/Scripts/PreDeployment.sql
+++ b/src/DokkanDailyDB/Pre-Deployment/Scripts/PreDeployment.sql
@@ -1,0 +1,14 @@
+/* Remove historical duplicates before the one-clear-per-user-per-day constraint is applied. */
+IF OBJECT_ID('Core.StageClear', 'U') IS NOT NULL
+BEGIN
+    ;WITH DuplicateClears AS (
+        SELECT
+            StageClearId,
+            ROW_NUMBER() OVER (
+                PARTITION BY DokkanDailyUserId, ClearDate
+                ORDER BY IsDailyHighscore DESC, ItemlessClear DESC, StageClearId DESC) AS DuplicateRank
+        FROM Core.StageClear WITH (TABLOCKX, HOLDLOCK)
+    )
+    DELETE FROM DuplicateClears WHERE DuplicateRank > 1;
+END
+GO

--- a/tests/DokkanDailyTests/DatabaseTests.cs
+++ b/tests/DokkanDailyTests/DatabaseTests.cs
@@ -24,7 +24,7 @@ namespace DokkanDailyTests
         public void OneTimeSetup()
         {
             Mock<ILogger<DokkanDailyRepository>> mock = new(MockBehavior.Loose);
-            string sqlServerConnectionString = "Data Source=.,1433;Initial Catalog=mydatabase;Persist Security Info=True;User ID=SA;Password=<YourStrong@Passw0rd>;TrustServerCertificate=True;";
+            string sqlServerConnectionString = "Data Source=127.0.0.1,1433;Initial Catalog=mydatabase;Persist Security Info=True;User ID=SA;Password=<YourStrong@Passw0rd>;TrustServerCertificate=True;";
             conn = new(sqlServerConnectionString);
 
             // todo: docker stuff here
@@ -80,6 +80,57 @@ namespace DokkanDailyTests
             var list = result.ToList();
             Assert.That(list, Has.Count.EqualTo(2), "the returned leaderboard should have the correct number of elements");
             Assert.That(list.Any(x => x.DiscordId == "112089455933792256"), Is.True, "an element should contain a discord id");
+        }
+
+        [Test]
+        public async Task ADiscordIdBackfillsTheMatchingLegacyUserWithoutCreatingADuplicate()
+        {
+            await conn.OpenAsync();
+            await conn.ExecuteAsync("INSERT INTO Core.DokkanDailyUser (DokkanNickname, DiscordUsername) VALUES ('legacy', 'legacy-user')");
+            await conn.CloseAsync();
+
+            await repository.InsertDailyClears([
+                new DbClear
+                {
+                    DokkanNickname = "legacy",
+                    DiscordUsername = "legacy-user",
+                    DiscordId = "123456789",
+                    ItemlessClear = false,
+                    ClearTime = "0'10\"00.0"
+                }
+            ], DateTime.UtcNow.Date);
+
+            await conn.OpenAsync();
+            var users = (await conn.QueryAsync<(int Count, string DiscordId)>(
+                "SELECT COUNT(*) AS [Count], MAX(DiscordId) AS DiscordId FROM Core.DokkanDailyUser WHERE DiscordUsername = 'legacy-user' GROUP BY DiscordUsername")).Single();
+            await conn.CloseAsync();
+
+            Assert.That(users.Count, Is.EqualTo(1));
+            Assert.That(users.DiscordId, Is.EqualTo("123456789"));
+        }
+
+        [Test]
+        public async Task ConcurrentResetWritesCreateOnlyOneClearPerUserAndDay()
+        {
+            DateTime date = DateTime.UtcNow.Date;
+            DbClear clear = new()
+            {
+                DokkanNickname = "concurrent-user",
+                ItemlessClear = true,
+                IsDailyHighscore = true,
+                ClearTime = "0'10\"00.0"
+            };
+
+            await Task.WhenAll(Enumerable.Range(0, 12)
+                .Select(_ => repository.InsertDailyClears([clear], date)));
+
+            await conn.OpenAsync();
+            int count = await conn.QuerySingleAsync<int>(
+                "SELECT COUNT(*) FROM Core.StageClear C INNER JOIN Core.DokkanDailyUser U ON U.DokkanDailyUserId = C.DokkanDailyUserId WHERE U.DokkanNickname = 'concurrent-user' AND C.ClearDate = @date",
+                new { date });
+            await conn.CloseAsync();
+
+            Assert.That(count, Is.EqualTo(1));
         }
 
         [Test]

--- a/tests/DokkanDailyTests/ServiceTests.cs
+++ b/tests/DokkanDailyTests/ServiceTests.cs
@@ -206,8 +206,14 @@ namespace DokkanDailyTests
                         { AzureConstants.CLEAR_TIME_TAG, "0'30\"10.8" },
                         { AzureConstants.ITEMLESS_TAG, "true" }
                     }),
+                    new MockBlobClient(new Dictionary<string, string>()
+                    {
+                        { AzureConstants.USER_NAME_TAG, "still-processing" },
+                        { AzureConstants.UPLOAD_STATUS_TAG, AzureConstants.UPLOAD_STATUS_PENDING }
+                    }),
                 ]);
             abMock.Setup(x => x.PruneContainers(30)).Returns(Task.CompletedTask);
+            abMock.Setup(x => x.WaitForPendingAnalysis(It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
             abMock.Setup(x => x.GetBucketNameForDate(It.IsAny<string>())).Returns(It.IsAny<string>());
 
             repoMock
@@ -233,8 +239,8 @@ namespace DokkanDailyTests
 
             List<DbClear> exp =
             [
-                new() { DokkanNickname = "omni", ClearTime = "0'20\"10.8", IsDailyHighscore = false, ItemlessClear = true, ClearTimeSpan = new TimeSpan(0, 0, 20, 10, 800) },
-                new() { DokkanNickname = "owl", ClearTime = "0'18\"10.8", IsDailyHighscore = true, ItemlessClear = false, ClearTimeSpan = new TimeSpan(0, 0, 18, 10, 800) },
+                new() { DokkanNickname = "omni", ClearTime = "0'19\"10.8", IsDailyHighscore = false, ItemlessClear = true, ClearTimeSpan = new TimeSpan(0, 0, 19, 10, 800) },
+                new() { DokkanNickname = "owl", ClearTime = "0'18\"10.8", IsDailyHighscore = true, ItemlessClear = true, ClearTimeSpan = new TimeSpan(0, 0, 18, 10, 800) },
                 new() { DokkanNickname = "rabs", ClearTime = "0'30\"10.8", IsDailyHighscore = false, ItemlessClear = true, ClearTimeSpan = new TimeSpan(0, 0, 30, 10, 800) }
             ];
 
@@ -248,6 +254,7 @@ namespace DokkanDailyTests
             lbMock.VerifyNoOtherCalls();
 
             abMock.Verify(x => x.PruneContainers(It.IsAny<int>()), Times.Once);
+            abMock.Verify(x => x.WaitForPendingAnalysis(It.IsAny<TimeSpan>()), Times.Once);
             abMock.Verify(x => x.GetBucketNameForDate(It.IsAny<string>()));
             abMock.Verify(x => x.GetFilesForTag(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             abMock.VerifyNoOtherCalls();

--- a/tests/DokkanDailyTests/ServiceTests.cs
+++ b/tests/DokkanDailyTests/ServiceTests.cs
@@ -213,6 +213,9 @@ namespace DokkanDailyTests
                     }),
                 ]);
             abMock.Setup(x => x.PruneContainers(30)).Returns(Task.CompletedTask);
+            var resetBarrierMock = mocks.Create<IAsyncDisposable>();
+            resetBarrierMock.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
+            abMock.Setup(x => x.AcquireResetBarrierAsync()).ReturnsAsync(resetBarrierMock.Object);
             abMock.Setup(x => x.WaitForPendingAnalysis(It.IsAny<TimeSpan>())).Returns(Task.CompletedTask);
             abMock.Setup(x => x.GetBucketNameForDate(It.IsAny<string>())).Returns(It.IsAny<string>());
 
@@ -254,6 +257,7 @@ namespace DokkanDailyTests
             lbMock.VerifyNoOtherCalls();
 
             abMock.Verify(x => x.PruneContainers(It.IsAny<int>()), Times.Once);
+            abMock.Verify(x => x.AcquireResetBarrierAsync(), Times.Once);
             abMock.Verify(x => x.WaitForPendingAnalysis(It.IsAny<TimeSpan>()), Times.Once);
             abMock.Verify(x => x.GetBucketNameForDate(It.IsAny<string>()));
             abMock.Verify(x => x.GetFilesForTag(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
@@ -262,6 +266,8 @@ namespace DokkanDailyTests
             repoMock.Verify(x => x.InsertDailyClears(It.IsAny<IEnumerable<DbClear>>(), It.IsAny<DateTime>()), Times.Once);
             repoMock.Verify(x => x.InsertChallenge(It.IsAny<Challenge>()), Times.Once);
             repoMock.VerifyNoOtherCalls();
+
+            resetBarrierMock.Verify(x => x.DisposeAsync(), Times.Once);
 
             webhookMock.Verify(x => x.PostAsync(It.IsAny<WebhookMessage>()), Times.Once);
             webhookMock.VerifyNoOtherCalls();


### PR DESCRIPTION
## Summary
- drain in-flight OCR before daily scoring and skip unfinished uploads
- preserve fastest-run and itemless scoring independently per user
- resolve users by strongest safe identity while supporting legacy Discord ID backfill
- serialize reset writes and enforce one clear per user per day
- deduplicate historical clears before adding the database constraint

## Validation
- complete test suite passes (193/193; snapshot generator excluded)
- SSDT database project rebuild passes
- DACPAC publishes to the local SQL test container